### PR TITLE
exchange operator overload for explicit `evaluate`

### DIFF
--- a/sfo_cpp/optimizers/monotone/lazier_than_lazy_greedy.hpp
+++ b/sfo_cpp/optimizers/monotone/lazier_than_lazy_greedy.hpp
@@ -248,7 +248,7 @@ private:
                 continue;
             }
 
-            candidate.second = cost_function->operator()(test_set) - curr_val;
+            candidate.second = cost_function->evaluate(test_set) - curr_val;
 
             // put updated candidate back into priority queue
             sampled_marginals.pop();

--- a/sfo_cpp/optimizers/monotone/lazy_greedy.hpp
+++ b/sfo_cpp/optimizers/monotone/lazy_greedy.hpp
@@ -163,7 +163,7 @@ private:
 
             // build out candidate pair
             candidate.first = *el;
-            candidate.second = cost_function->operator()(test_set) - curr_val;
+            candidate.second = cost_function->evaluate(test_set) - curr_val;
 
             marginals.push(candidate);
         }
@@ -219,7 +219,7 @@ private:
             }
 
             candidate.first = *el;
-            pure_vals.insert({candidate.first, cost_function->operator()(test_set) - curr_val});
+            pure_vals.insert({candidate.first, cost_function->evaluate(test_set) - curr_val});
             pure_knaps.insert({candidate.first, K->value(test_set) - curr_budget});
             candidate.second = pure_vals[candidate.first] / pure_knaps[candidate.first];
 
@@ -271,7 +271,7 @@ private:
                 continue; // leave element out from now on
             }
 
-            candidate.second = cost_function->operator()(test_set) - curr_val;
+            candidate.second = cost_function->evaluate(test_set) - curr_val;
 
             // put updated candidate back into priority queue
             marginals.pop();
@@ -328,7 +328,7 @@ private:
                 continue; // leave element out from now on
             }
 
-            pure_vals.insert({candidate.first, cost_function->operator()(test_set) - curr_val});
+            pure_vals.insert({candidate.first, cost_function->evaluate(test_set) - curr_val});
             pure_knaps.insert({candidate.first, K->value(test_set) - curr_budget});
             candidate.second = pure_vals[candidate.first] / pure_knaps[candidate.first];
 

--- a/sfo_cpp/optimizers/monotone/stochastic_greedy.hpp
+++ b/sfo_cpp/optimizers/monotone/stochastic_greedy.hpp
@@ -239,7 +239,7 @@ private:
             }
 
             // update marginal value
-            candidate_marginal_val = cost_function->operator()(test_set) - curr_val;
+            candidate_marginal_val = cost_function->evaluate(test_set) - curr_val;
 
             // keep running track of highest marginal value element
             if (candidate_marginal_val > best_marginal_val)

--- a/sfo_cpp/optimizers/monotone/vanilla_greedy.hpp
+++ b/sfo_cpp/optimizers/monotone/vanilla_greedy.hpp
@@ -79,7 +79,7 @@ public:
         this->curr_set.clear();
         if (this->cost_function)
         {
-            this->curr_val = this->cost_function->operator()(curr_set);
+            this->curr_val = this->cost_function->evaluate(curr_set);
         }
         else
         {
@@ -180,7 +180,7 @@ private:
             }
 
             // update marginal value
-            candidate_marginal_val = cost_function->operator()(test_set) - curr_val;
+            candidate_marginal_val = cost_function->evaluate(test_set) - curr_val;
 
             // keep running track of highest marginal value element
             if (candidate_marginal_val > best_marginal_val)
@@ -234,7 +234,7 @@ private:
 
             // update marginal value
             candidate_marginal_cost = K->value(test_set) - curr_budget;
-            candidate_marginal_val = cost_function->operator()(test_set) - curr_val;
+            candidate_marginal_val = cost_function->evaluate(test_set) - curr_val;
 
             // keep running track of highest marginal value element
             if (candidate_marginal_val / candidate_marginal_cost > best_marginal_val / best_marginal_cost)

--- a/sfo_cpp/optimizers/non_monotone/apx_local_search.hpp
+++ b/sfo_cpp/optimizers/non_monotone/apx_local_search.hpp
@@ -106,7 +106,7 @@ public:
         {
             // for each constraint, run a local search, save values
             candidate = local_search_procedure();
-            test_value = cost_function->operator()(candidates[i]);
+            test_value = cost_function->evaluate(candidates[i]);
 
             // check for new maximum
             if (test_value > value)
@@ -139,7 +139,7 @@ private:
             if (this->check_constraints(*it))
             {
                 // if element is feasible, compute its value
-                test_val = cost_function->operator()(*it);
+                test_val = cost_function->evaluate(*it);
 
                 // save it if it is better than current best
                 if (test_val > curr_val)
@@ -178,7 +178,7 @@ private:
             }
 
             // update marginal value
-            candidate_marginal_val = cost_function->operator()(test_set) - curr_val;
+            candidate_marginal_val = cost_function->evaluate(test_set) - curr_val;
 
             // keep running track of highest marginal value element
             if (candidate_marginal_val > best_marginal_val)

--- a/sfo_cpp/optimizers/non_monotone/bidirectional_greedy.hpp
+++ b/sfo_cpp/optimizers/non_monotone/bidirectional_greedy.hpp
@@ -58,7 +58,7 @@ public:
         {
             this->top_set = *ground_set;
             this->bottom_set.clear();
-            this->top_val = cost_function->operator()(top_set);
+            this->top_val = cost_function->evaluate(top_set);
             this->bottom_val = 0;
             this->MAXITER = this->n;
             int counter = 0;
@@ -111,11 +111,11 @@ private:
         test_set = bottom_set;
 
         test_set.insert(el);
-        bottom_gain = cost_function->operator()(test_set) - bottom_val;
+        bottom_gain = cost_function->evaluate(test_set) - bottom_val;
 
         test_set = top_set;
         test_set.erase(el);
-        top_gain = cost_function->operator()(test_set) - top_val;
+        top_gain = cost_function->evaluate(test_set) - top_val;
 
         if (this->randomized)
         {

--- a/sfo_cpp/sfo_concepts/constraint.hpp
+++ b/sfo_cpp/sfo_concepts/constraint.hpp
@@ -61,32 +61,32 @@ namespace constraint
 
         bool test_membership(E *el)
         {
-            return modular(el) <= budget;
+            return modular.evaluate(el) <= budget;
         }
 
         bool test_membership(std::unordered_set<E *> &set)
         {
-            return modular(set) <= budget;
+            return modular.evaluate(set) <= budget;
         }
 
         bool is_saturated(std::unordered_set<E *> &test_set)
         {
-            return std::abs(modular(test_set) - budget) < std::numeric_limits<float>::epsilon();
+            return std::abs(modular.evaluate(test_set) - budget) < std::numeric_limits<float>::epsilon();
         }
 
         bool is_saturated(E *el)
         {
-            return std::abs(modular(el) - budget) < std::numeric_limits<float>::epsilon();
+            return std::abs(modular.evaluate(el) - budget) < std::numeric_limits<float>::epsilon();
         }
 
         double value(std::unordered_set<E *> &test_set)
         {
-            return modular(test_set);
+            return modular.evaluate(test_set);
         }
 
         double value(E *el)
         {
-            return modular(el);
+            return modular.evaluate(el);
         }
     };
 

--- a/sfo_cpp/sfo_concepts/cost_function.hpp
+++ b/sfo_cpp/sfo_concepts/cost_function.hpp
@@ -13,8 +13,8 @@ namespace costfunction
         // Cost functions are given POINTERS to ELEMENTS, returning an evaluation
     public:
         virtual ~CostFunction(){}; // destructor
-        virtual double operator()(std::unordered_set<E *> &set) = 0;
-        virtual double operator()(E *&el) = 0;
+        virtual double evaluate(std::unordered_set<E *> &set) = 0;
+        virtual double evaluate(E *&el) = 0;
 
         // marginal gain functions
         virtual double marginal_gain(E *&el, std::unordered_set<E *> &context)
@@ -24,7 +24,7 @@ namespace costfunction
              */
             std::unordered_set<E *> testset(context);
             testset.insert(el);
-            return this->operator()(testset) - this->operator()(context);
+            return this->evaluate(testset) - this->evaluate(context);
         }
         virtual double marginal_gain(E *&el, std::unordered_set<E *> &context, double &curr_val)
         {
@@ -33,7 +33,7 @@ namespace costfunction
              */
             std::unordered_set<E *> testset(context);
             testset.insert(el);
-            return this->operator()(testset) - curr_val;
+            return this->evaluate(testset) - curr_val;
         }
     };
 
@@ -59,7 +59,7 @@ namespace costfunction
             weights.insert({nullptr, 1});
         }
 
-        double operator()(std::unordered_set<E *> &set)
+        double evaluate(std::unordered_set<E *> &set)
         {
             if (weights.size() == 1)
             {
@@ -73,7 +73,7 @@ namespace costfunction
             return val;
         }
 
-        double operator()(E *&el)
+        double evaluate(E *&el)
         {
             if (weights.size() == 1)
             {
@@ -87,29 +87,29 @@ namespace costfunction
     };
 
     template <typename E>
-    class SquareRootModular : public CostFunction<E>
+    class SqrtModular : public CostFunction<E>
     {
     public:
         Modular<E> modular_part;
 
-        SquareRootModular(const Modular<E> &m)
+        SqrtModular(const Modular<E> &m)
         {
             modular_part = m;
         }
 
-        SquareRootModular()
+        SqrtModular()
         {
             modular_part = Modular<E>();
         }
 
-        double operator()(std::unordered_set<E *> &set)
+        double evaluate(std::unordered_set<E *> &set)
         {
-            return std::sqrt(modular_part(set));
+            return std::sqrt(modular_part.evaluate(set));
         }
 
-        double operator()(E *&el)
+        double evaluate(E *&el)
         {
-            return std::sqrt(modular_part(el));
+            return std::sqrt(modular_part.evaluate(el));
         }
     };
 
@@ -136,12 +136,12 @@ namespace costfunction
 
         double operator()(std::unordered_set<E *> &set)
         {
-            return high - std::sqrt(std::abs(modular_part(set) - bias));
+            return high - std::sqrt(std::abs(modular_part.evaluate(set) - bias));
         }
 
         double operator()(E *&el)
         {
-            return high - std::sqrt(std::abs(modular_part(el) - bias));
+            return high - std::sqrt(std::abs(modular_part.evaluate(el) - bias));
         }
     };
 }

--- a/sfo_cpp/tests/test_non_monotone_greedy.cpp
+++ b/sfo_cpp/tests/test_non_monotone_greedy.cpp
@@ -30,7 +30,7 @@ TEST_F(ConstrainedModularCost, BidirectionalGreedyTest)
 
     // We should have the optimal cost, since the cost function is modular.
     // Since the problem is unconstrained and monotone modular, the optimal should just be all elements.
-    EXPECT_FLOAT_EQ(greedy.curr_val, cost_function->operator()(*ground_set)) << "Optimizer result: " << greedy.curr_val << " Optimal: " << optimal_value;
+    EXPECT_FLOAT_EQ(greedy.curr_val, cost_function->evaluate(*ground_set)) << "Optimizer result: " << greedy.curr_val << " Optimal: " << optimal_value;
     EXPECT_EQ(greedy.curr_set, *ground_set) << "Optimizer set: " << greedy.curr_set << " Optimal: " << optimal_set;
 }
 
@@ -46,7 +46,7 @@ TEST_F(SqrtModularCost, BidirectionalGreedyTest)
 
     // We should have the optimal cost, since the cost function is modular.
     // Since the problem is unconstrained and monotone modular, the optimal should just be all elements.
-    EXPECT_FLOAT_EQ(greedy.curr_val, cost_function->operator()(*ground_set)) << "Optimizer result: " << greedy.curr_val << " Optimal: " << optimal_value;
+    EXPECT_FLOAT_EQ(greedy.curr_val, cost_function->evaluate(*ground_set)) << "Optimizer result: " << greedy.curr_val << " Optimal: " << optimal_value;
     EXPECT_EQ(greedy.curr_set, *ground_set) << "Optimizer set: " << greedy.curr_set << " Optimal: " << optimal_set;
 }
 
@@ -63,7 +63,7 @@ TEST_F(ConstrainedModularCost, RandomizedBidirectionalGreedyTest)
 
     // We should have the optimal cost, since the cost function is modular.
     // Since the problem is unconstrained and monotone modular, the optimal should just be all elements.
-    EXPECT_FLOAT_EQ(greedy.curr_val, cost_function->operator()(*ground_set)) << "Optimizer result: " << greedy.curr_val << " Optimal: " << optimal_value;
+    EXPECT_FLOAT_EQ(greedy.curr_val, cost_function->evaluate(*ground_set)) << "Optimizer result: " << greedy.curr_val << " Optimal: " << optimal_value;
     EXPECT_EQ(greedy.curr_set, *ground_set) << "Optimizer set: " << greedy.curr_set << " Optimal: " << optimal_set;
 }
 
@@ -79,6 +79,6 @@ TEST_F(SqrtModularCost, RandomizedBidirectionalGreedyTest)
 
     // We should have the optimal cost, since the cost function is modular.
     // Since the problem is unconstrained and monotone modular, the optimal should just be all elements.
-    EXPECT_FLOAT_EQ(greedy.curr_val, cost_function->operator()(*ground_set)) << "Optimizer result: " << greedy.curr_val << " Optimal: " << optimal_value;
+    EXPECT_FLOAT_EQ(greedy.curr_val, cost_function->evaluate(*ground_set)) << "Optimizer result: " << greedy.curr_val << " Optimal: " << optimal_value;
     EXPECT_EQ(greedy.curr_set, *ground_set) << "Optimizer set: " << greedy.curr_set << " Optimal: " << optimal_set;
 }

--- a/sfo_cpp/tests/test_utils/test_fixtures.hpp
+++ b/sfo_cpp/tests/test_utils/test_fixtures.hpp
@@ -74,8 +74,8 @@ protected:
             weights.insert({el, value * value});
         }
 
-        this->modular = costfunction::Modular(weights);                     // modular part of cost
-        this->cost_function = new costfunction::SquareRootModular(modular); // square root of modular
+        this->modular = costfunction::Modular(weights);               // modular part of cost
+        this->cost_function = new costfunction::SqrtModular(modular); // square root of modular
 
         // Extract the optimal value and set (largest `budget` elements.)
         std::vector<std::pair<Element *, double>> top_elements(budget);


### PR DESCRIPTION
## Background

Previously, I set up the `CostFunction` class to have its `operator()` method overloaded for "function evaluations."  While this looked a lot more mathematical, I found many situations where I still had to type the full `cost_function->operator()(set)`, which defeats the whole purpose of doing the operator overload in the first place.

## Description

In this PR, I rename the `operator()` methods to simple `evaluate()` methods so that function evaluations are just calls to a cost function's `evaluate` method.

## Verification

All existing tests still pass.