### PR TITLE
fix job name

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -11,7 +11,7 @@ on:
       - main
 
 jobs:
-  test-the-tub:
+  test-sfo-cpp:
     runs-on: ubuntu-latest
     steps:
       - run: echo "Tests triggered by a ${{ github.event_name }} off branch ${{ github.ref }}."


### PR DESCRIPTION
## Background

The main CI job is still named from when I stole it from my other repo.

## Description

Check the yaml, job names in CI.

## Verification

How do you know that this worked? Screenshots are appropriate here.